### PR TITLE
增加配置文件修改后重新加载环境变量的方法

### DIFF
--- a/openresty/install_on_centos.md
+++ b/openresty/install_on_centos.md
@@ -42,7 +42,8 @@
 
 ####设置环境变量
 
-为了后面启动OpenResty的命令简单一些，不用在OpenResty的安装目录下进行启动，我们通过设置环境变量来简化操作。将OpenResty目录下的nginx/sbin目录添加到PATH中。就是打开文件 /etc/profile，在文件末尾加入```export PATH=$PATH:/opt/openresty/nginx/sbin```，若你的安装目录不一样，则做相应修改。注意：这一步操作需要重启才会生效。
+为了后面启动OpenResty的命令简单一些，不用在OpenResty的安装目录下进行启动，我们通过设置环境变量来简化操作。将OpenResty目录下的nginx/sbin目录添加到PATH中。就是打开文件 /etc/profile，在文件末尾加入```export PATH=$PATH:/opt/openresty/nginx/sbin```，若你的安装目录不一样，则做相应修改。
+注意：这一步操作需要重新加载环境变量才会生效，可通过命令```source /etc/profile```或者重启服务器等方式实现。
 
 接下来，我们就可以进入到后面的章节[HelloWorld](helloworld.md)学习。
 


### PR DESCRIPTION
linux在修改环境变量之后，可以通过多种方式实现环境变量的重载，重启只是其中一种方法，这里只写重载容易给读者实际使用造成困扰。
这可能是当时书写时比较仓促导致的小错误。

Signed-off-by: Bo Cai <cai.bo@h3c.com>