### PR TITLE
修改add重载输出内容排序

### DIFF
--- a/lua/metatable.md
+++ b/lua/metatable.md
@@ -45,7 +45,7 @@ setmetatable(set1, {__add = union}) -- 重载 set1 表的 __add 元方法
 
 local set3 = set1 + set2
 for _, j in pairs(set3) do
-	io.write(j.." ")               -->output：30 50 20 40 10
+	io.write(j.." ")               -->output：10 30 20 40 50
 end
 ```
 


### PR DESCRIPTION
原先输出内容提示为-->output：30 50 20 40 10，在lua5.2下发现实际输出为-->output:10 30 20 40 50